### PR TITLE
Add option for filename in target

### DIFF
--- a/CachedResourcesGrailsPlugin.groovy
+++ b/CachedResourcesGrailsPlugin.groovy
@@ -12,8 +12,8 @@ class CachedResourcesGrailsPlugin {
             "web-app/js/**/*.*"
     ]
 
-    def author = "Marc Palmer"
-    def authorEmail = "marc@grailsrocks.com"
+    def developers = [ [name: "Marc Palmer", email: "marc@grailsrocks.com"] ]
+    
     def title = "Cached Resources"
     def description = '''\\
 Makes static resources browser-cacheable with unique filenames based on their content

--- a/CachedResourcesGrailsPlugin.groovy
+++ b/CachedResourcesGrailsPlugin.groovy
@@ -1,5 +1,5 @@
 class CachedResourcesGrailsPlugin {
-    def version = "1.1"
+    def version = "1.2"
 
     def grailsVersion = "1.2 > *"
     // the other plugins this plugin depends on

--- a/CachedResourcesGrailsPlugin.groovy
+++ b/CachedResourcesGrailsPlugin.groovy
@@ -1,9 +1,8 @@
 class CachedResourcesGrailsPlugin {
-    def version = "1.0"
+    def version = "1.1"
 
     def grailsVersion = "1.2 > *"
     // the other plugins this plugin depends on
-    def dependsOn = [resources:'1.0.RC3 > *', cacheHeaders:'1.0.4 > *']
     def loadAfter = ['resources']
     
     // resources that are excluded from plugin packaging

--- a/README.txt
+++ b/README.txt
@@ -5,25 +5,23 @@ It then sets long term caching headers on the resources when rendering them.
 
 Resources can be excluded via Ant-style expressions:
 
-grails.cached.resources.excludes = [
-    "*.png",
-    "**/*.jpg"
-]
+    grails.cached.resources.excludes = [
+        "*.png",
+        "**/*.jpg"
+    ]
 
-Builds on the "Resources" framework plugin 
+Builds on the "Resources" framework plugin
 
 Todos:
 
-* Make the "excludes" option accept closures in addition to Ant-style
-  expressions, so that it can be determined at runtime. For example:
+* Improve the "excludes" option to accept closures in addition to Ant-style
+  expressions. For example:
 
-  cached.resources.excludes = [
-	  '*.pdf',
-	  'assets/',
-	  { uri ->
-	  	  return !uri.startsWith('catalogue')
-	  }
-  ]
-
-
+    grails.cached.resources.excludes = [
+        '*.pdf',
+        'assets/',
+        { uri ->
+            return !uri.startsWith('catalogue')
+        }
+    ]
 

--- a/README.txt
+++ b/README.txt
@@ -3,13 +3,19 @@ This plugin calculates SHA256 hashes of your static resources and renames them t
 
 It then sets long term caching headers on the resources when rendering them.
 
+Resources can be excluded via Ant-style expressions:
+
+grails.cached.resources.excludes = [
+    "*.png",
+    "**/*.jpg"
+]
+
 Builds on the "Resources" framework plugin 
 
 Todos:
 
-* Add "excludes" URIs via Config to prevent certain types and URIs being handled in this way - 
-  e.g. sites with lots of photos or where a filename is important e.g. Catalogue-2010.pdf
-  Allow closure to determine it at runtime. e.g.:
+* Make the "excludes" option accept closures in addition to Ant-style
+  expressions, so that it can be determined at runtime. For example:
 
   cached.resources.excludes = [
 	  '*.pdf',

--- a/application.properties
+++ b/application.properties
@@ -1,7 +1,7 @@
 #Grails Metadata file
-#Tue Sep 11 16:58:34 BST 2012
-app.grails.version=2.0.4
+#Mon Jun 24 19:02:05 MST 2013
+app.grails.version=2.2.2
 app.name=CachedResources
 plugins.cache-headers=1.0.4
-plugins.hibernate=2.0.4
-plugins.tomcat=2.0.4
+plugins.hibernate=2.2.2
+plugins.tomcat=2.2.2

--- a/application.properties
+++ b/application.properties
@@ -1,8 +1,7 @@
 #Grails Metadata file
-#Tue May 03 11:53:41 BST 2011
-app.grails.version=1.3.7
+#Tue Sep 11 16:58:34 BST 2012
+app.grails.version=2.0.4
 app.name=CachedResources
 plugins.cache-headers=1.0.4
-plugins.hibernate=1.3.7
-plugins.resources=1.0-RC3
-plugins.tomcat=1.3.7
+plugins.hibernate=2.0.4
+plugins.tomcat=2.0.4

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -28,5 +28,8 @@ grails.project.dependency.resolution = {
 
         // runtime 'mysql:mysql-connector-java:5.1.5'
     }
-
+    plugins {
+        compile ":resources:1.1.6"
+        compile ":cache-headers:1.0.4"
+    }
 }

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -29,6 +29,12 @@ grails.project.dependency.resolution = {
         // runtime 'mysql:mysql-connector-java:5.1.5'
     }
     plugins {
+        build(":tomcat:$grailsVersion",
+              ":release:2.0.3",
+              ":rest-client-builder:1.0.2") {
+            export = false
+        }
+
         compile ":resources:1.1.6"
         compile ":cache-headers:1.0.4"
     }

--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -24,6 +24,9 @@ log4j = {
 grails.resources.adhoc.patterns = ["/images/*", "*.css", "*.js"].asImmutable()
 grails.cached.resources.flatten = false
 grails.cached.resources.shortlinks = false
+grails.cached.resources.excludes = [
+    // Add Ant-style exclude patterns here
+]
 
 environments {
     development {

--- a/grails-app/conf/DataSource.groovy
+++ b/grails-app/conf/DataSource.groovy
@@ -1,6 +1,6 @@
 dataSource {
 	pooled = true
-	driverClassName = "org.hsqldb.jdbcDriver"
+	driverClassName = "org.h2.Driver"
 	username = "sa"
 	password = ""
 }
@@ -14,13 +14,13 @@ environments {
 	development {
 		dataSource {
 			dbCreate = "create-drop" // one of 'create', 'create-drop','update'
-			url = "jdbc:hsqldb:mem:devDB"
+			url = "jdbc:h2:mem:devDB"
 		}
 	}
 	test {
 		dataSource {
 			dbCreate = "update"
-			url = "jdbc:hsqldb:mem:testDb"
+			url = "jdbc:h2:mem:testDb"
 		}
 	}
 	production {

--- a/test/unit/org/grails/plugin/cacheresources/CachedResourceServiceTests.groovy
+++ b/test/unit/org/grails/plugin/cacheresources/CachedResourceServiceTests.groovy
@@ -1,17 +1,12 @@
 package org.grails.plugin.cacheresources
 
-import grails.test.*
-
-class CachedResourceServiceTests extends GrailsUnitTestCase {
-    protected void setUp() {
-        super.setUp()
+class CachedResourceServiceTests {
+    public void setUp() {
     }
 
-    protected void tearDown() {
-        super.tearDown()
+    public void tearDown() {
     }
 
-    void testSomething() {
-
+    public void testSomething() {
     }
 }

--- a/test/unit/org/grails/plugin/cacheresources/HashAndCacheResourceMapperTests.groovy
+++ b/test/unit/org/grails/plugin/cacheresources/HashAndCacheResourceMapperTests.groovy
@@ -1,0 +1,72 @@
+package org.grails.plugin.cacheresources
+
+import com.grailsrocks.cacheheaders.CacheHeadersService
+import grails.test.mixin.TestFor
+import org.grails.plugin.cachedresources.HashAndCacheResourceMapper
+import org.grails.plugin.resource.ResourceMeta
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@TestFor(CacheHeadersService)
+class HashAndCacheResourceMapperTests {
+    MockResourceService resourceService
+    HashAndCacheResourceMapper mapper
+
+    @Before
+    public void setUp() {
+        grailsApplication.config.grails.cached.resources.excludes = [
+                "*.png"
+        ]
+
+        resourceService = new MockResourceService()
+        mapper = new HashAndCacheResourceMapper(grailsApplication: grailsApplication, resourceService: resourceService)
+    }
+
+    @After
+    public void tearDown() {
+    }
+
+    @Test
+    void testExclusionFilters() {
+        File pngFile = File.createTempFile("boring-", ".png", resourceService.workDir)
+        File gifFile = File.createTempFile("boring-", ".gif", resourceService.workDir)
+
+        pngFile << "blahblahblah".getBytes("UTF-8")
+        pngFile.deleteOnExit()
+
+        gifFile << "blarblarblar".getBytes("UTF-8")
+        gifFile.deleteOnExit()
+
+        ResourceMeta pngFileMeta = new ResourceMeta(
+                sourceUrl: pngFile.getName(),
+                sourceUrlExtension: "png",
+                processedFile: pngFile,
+                workDir: resourceService.workDir
+        )
+
+        ResourceMeta gifFileMeta = new ResourceMeta(
+                sourceUrl: gifFile.getName(),
+                sourceUrlExtension: "gif",
+                processedFile: gifFile,
+                workDir: resourceService.workDir
+        )
+
+        mapper.map(pngFileMeta, null)
+        mapper.map(gifFileMeta, null)
+
+        assertEquals("PNG should not have been renamed", pngFileMeta.processedFile.name, pngFile.name)
+        assertFalse("GIF should have been renamed", gifFileMeta.processedFile.name == gifFile.name)
+
+        pngFileMeta.processedFile.delete()
+        gifFileMeta.processedFile.delete()
+    }
+
+    class MockResourceService {
+        def workDir = new File(System.getProperty("java.io.tmpdir"))
+
+        def getConfigParamOrDefault(param, defaultValue) {
+            return defaultValue
+        }
+    }
+}


### PR DESCRIPTION
Having the filename in the browser makes it easier to debug scripts. By combining the filename and hash developers get the benefit of debugging and the accurate browser cache.
